### PR TITLE
Add food recipe join table

### DIFF
--- a/app/models/food.rb
+++ b/app/models/food.rb
@@ -1,5 +1,6 @@
 class Food < ApplicationRecord
   belongs_to :user
+  has_and_belongs_to_many :recipes
 
   validates :name, presence: true
   validates :price, presence: true, numericality: { only_integer: true }

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -1,5 +1,6 @@
 class Recipe < ApplicationRecord
   belongs_to :user
+  has_and_belongs_to_many :foods
 
   validates :name, presence: true
   validates :preparation_time, presence: true

--- a/db/migrate/20231117155529_create_foods_recipes_join_table.rb
+++ b/db/migrate/20231117155529_create_foods_recipes_join_table.rb
@@ -1,0 +1,11 @@
+class CreateFoodsRecipesJoinTable < ActiveRecord::Migration[7.1]
+  def change
+    create_table :ingredients_recipes, id: false do |t|
+      t.belongs_to :ingredient
+      t.belongs_to :recipe
+      t.integer :quantity
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_17_001529) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_17_155529) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -23,6 +23,16 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_17_001529) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_foods_on_user_id"
+  end
+
+  create_table "ingredients_recipes", id: false, force: :cascade do |t|
+    t.bigint "ingredient_id"
+    t.bigint "recipe_id"
+    t.integer "quantity"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["ingredient_id"], name: "index_ingredients_recipes_on_ingredient_id"
+    t.index ["recipe_id"], name: "index_ingredients_recipes_on_recipe_id"
   end
 
   create_table "recipes", force: :cascade do |t|


### PR DESCRIPTION
In this pull request, I have created a many-to-many relationship between the Food and Recipe models. I have created and applied a migration that updates the schema. Thus, an food/ingredient can be used in multiple recipes, and a recipe can have multiple ingredients.
